### PR TITLE
fix(common.class.php): remove deprecated  arg in PHP 8.0.0

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -581,7 +581,7 @@ JAVASCRIPT;
     */
    public static function checkRegex($regex) {
       // Avoid php notice when validating the regular expression
-      set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+      set_error_handler(function ($errno, $errstr, $errfile, $errline) {
       });
       $isValid = !(preg_match($regex, "") === false);
       restore_error_handler();


### PR DESCRIPTION
### Changes description

See : https://github.com/itsmng/formcreator/issues/55

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [x] Docs have been added/updated => Not required

### References

See : https://github.com/itsmng/formcreator/issues/55

Closes #55 